### PR TITLE
调整spot与 七天内过期，调整适应python2.x

### DIFF
--- a/check-reserved-elasticache-instance
+++ b/check-reserved-elasticache-instance
@@ -144,6 +144,8 @@ if not new_order_ri:
     print("\tNone")
 print("")
 
-print("Running on-demand Elasticache instances: %s" % sum(running_instances.values()))
-print("Reserved Elasticache instances:          %s" % sum(reserved_instances.values()))
+#print("Running on-demand Elasticache instances: %s" % sum(running_instances.values()))
+#print("Reserved Elasticache instances:          %s" % sum(reserved_instances.values()))
+print("Running on-demand Elasticache instances: %s" % sum(six.itervalues(running_instances)))
+print("Reserved Elasticache instances:          %s" % sum(six.itervalues(reserved_instances)))
 print("")

--- a/check-reserved-elasticache-instance
+++ b/check-reserved-elasticache-instance
@@ -144,8 +144,6 @@ if not new_order_ri:
     print("\tNone")
 print("")
 
-#print("Running on-demand Elasticache instances: %s" % sum(running_instances.values()))
-#print("Reserved Elasticache instances:          %s" % sum(reserved_instances.values()))
 print("Running on-demand Elasticache instances: %s" % sum(six.itervalues(running_instances)))
 print("Reserved Elasticache instances:          %s" % sum(six.itervalues(reserved_instances)))
 print("")

--- a/check-reserved-instances
+++ b/check-reserved-instances
@@ -19,13 +19,13 @@ parser.add_argument("--aws-secret-key", type=str, default=None,
                     help="AWS Secret Access Key. Defaults to the value of the "
                          "AWS_SECRET_ACCESS_KEY environment variable (if set)")
 parser.add_argument("--region", type=str, default="cn-north-1",
-                    help="AWS Region name. Default is 'cn-north-1';or '--region cn-northwest-1'")
+                    help="AWS Region name. Default is 'cn-north-1'")
 parser.add_argument("-w", "--warn-time", type=int, default=30,
                     help="Expire period for reserved instances in days. "
                          "Default is '30 days'")
 parser.add_argument("-e", "--expire-time", type=int, default=3,
                     help="Expired period for reserved instances in days. "
-                         "Default is '7 days'")
+                         "Default is '3 days'")
 parser.add_argument("-o", "--order-time", type=int, default=7,
                     help="Payment period for reserved instances in days. "
                          "Default is '7 days'")
@@ -90,8 +90,7 @@ new_order_ri = {}
 
 reservations = ec2_client.describe_reserved_instances()
 now = datetime.datetime.utcnow().replace(tzinfo=tzutc())
-order_process_time = 10
-day7_secend = 604800
+day7_second = 604800
 for ri in reservations['ReservedInstances']:
     key = (ri['ProductDescription'], ri['InstanceType'],
            ri['AvailabilityZone'] if 'AvailabilityZone' in ri else REGION)
@@ -101,8 +100,7 @@ for ri in reservations['ReservedInstances']:
     cha = expire_time - now
     if ri['State'] == 'retired':
         if (now - expire_time)  < datetime.timedelta(days=args.expire_time):
-#            if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - order_process_time)):
-                expired_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
+            expired_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
         continue
     if ri['State'] not in ('active', 'payment-pending'):
         continue
@@ -110,7 +108,7 @@ for ri in reservations['ReservedInstances']:
         reserved_instances.get(key, 0) + ri['InstanceCount']
     if (expire_time - now) < datetime.timedelta(days=args.warn_time):
         soon_expire_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
-    if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - order_process_time - day7_secend)):
+    if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - day7_second)):
         if (now - start_time) < datetime.timedelta(days=args.order_time):
             new_order_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
         
@@ -194,9 +192,6 @@ if not new_order_ri:
    print("\tNone")
 print("")
 
-#print("Running spot instances:        %s" % sum(spot_instances.values()))
-#print("Running on-demand instances:   %s" % sum(running_instances.values()))
-#print("Reserved instances:            %s" % sum(reserved_instances.values()))
 print("Running spot instances:        %s" % sum(six.itervalues(spot_instances)))
 print("Running on-demand instances:   %s" % sum(six.itervalues(running_instances)))
 print("Reserved instances:            %s" % sum(six.itervalues(reserved_instances)))

--- a/check-reserved-instances
+++ b/check-reserved-instances
@@ -23,7 +23,7 @@ parser.add_argument("--region", type=str, default="cn-north-1",
 parser.add_argument("-w", "--warn-time", type=int, default=30,
                     help="Expire period for reserved instances in days. "
                          "Default is '30 days'")
-parser.add_argument("-e", "--expire-time", type=int, default=7,
+parser.add_argument("-e", "--expire-time", type=int, default=3,
                     help="Expired period for reserved instances in days. "
                          "Default is '7 days'")
 parser.add_argument("-o", "--order-time", type=int, default=7,
@@ -51,10 +51,6 @@ spot_instances = {}
 instances = ec2.instances.all()
 running_instances = {}
 for i in instances:
-    if i.instance_lifecycle == 'spot':
-        spot_key = (platform, i.instance_lifecycle, i.instance_type, i.placement['AvailabilityZone'] if 'AvailabilityZone' in i.placement else REGION)
-        spot_instances[spot_key] = spot_instances.get(spot_key,0) + 1
-        continue
     if i.state['Name'] != 'running':
         continue
     image_id = i.image_id
@@ -77,8 +73,12 @@ for i in instances:
                             break
         except AttributeError:
             platform = 'Linux/UNIX'
-
         image_id_to_platform[image_id] = platform
+
+    if i.instance_lifecycle == 'spot':
+        spot_key = (platform, i.instance_lifecycle, i.instance_type, i.placement['AvailabilityZone'] if 'AvailabilityZone' in i.placement else REGION)
+        spot_instances[spot_key] = spot_instances.get(spot_key,0) + 1
+        continue
 
     key = (platform, i.instance_type, i.placement['AvailabilityZone'] if 'AvailabilityZone' in i.placement else REGION)
     running_instances[key] = running_instances.get(key, 0) + 1
@@ -91,6 +91,7 @@ new_order_ri = {}
 reservations = ec2_client.describe_reserved_instances()
 now = datetime.datetime.utcnow().replace(tzinfo=tzutc())
 order_process_time = 10
+day7_secend = 604800
 for ri in reservations['ReservedInstances']:
     key = (ri['ProductDescription'], ri['InstanceType'],
            ri['AvailabilityZone'] if 'AvailabilityZone' in ri else REGION)
@@ -100,7 +101,7 @@ for ri in reservations['ReservedInstances']:
     cha = expire_time - now
     if ri['State'] == 'retired':
         if (now - expire_time)  < datetime.timedelta(days=args.expire_time):
-            if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - order_process_time)):
+#            if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - order_process_time)):
                 expired_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
         continue
     if ri['State'] not in ('active', 'payment-pending'):
@@ -109,7 +110,7 @@ for ri in reservations['ReservedInstances']:
         reserved_instances.get(key, 0) + ri['InstanceCount']
     if (expire_time - now) < datetime.timedelta(days=args.warn_time):
         soon_expire_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
-    if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - order_process_time)):
+    if (expire_time - start_time) > datetime.timedelta(seconds=(duration_time - order_process_time - day7_secend)):
         if (now - start_time) < datetime.timedelta(days=args.order_time):
             new_order_ri[ri['ReservedInstancesId']] = key + (expire_time, ri['InstanceCount'])
         

--- a/check-reserved-instances
+++ b/check-reserved-instances
@@ -19,7 +19,7 @@ parser.add_argument("--aws-secret-key", type=str, default=None,
                     help="AWS Secret Access Key. Defaults to the value of the "
                          "AWS_SECRET_ACCESS_KEY environment variable (if set)")
 parser.add_argument("--region", type=str, default="cn-north-1",
-                    help="AWS Region name. Default is 'cn-north-1'")
+                    help="AWS Region name. Default is 'cn-north-1';or '--region cn-northwest-1'")
 parser.add_argument("-w", "--warn-time", type=int, default=30,
                     help="Expire period for reserved instances in days. "
                          "Default is '30 days'")
@@ -193,7 +193,10 @@ if not new_order_ri:
    print("\tNone")
 print("")
 
-print("Running spot instances:        %s" % sum(spot_instances.values()))
-print("Running on-demand instances:   %s" % sum(running_instances.values()))
-print("Reserved instances:            %s" % sum(reserved_instances.values()))
+#print("Running spot instances:        %s" % sum(spot_instances.values()))
+#print("Running on-demand instances:   %s" % sum(running_instances.values()))
+#print("Reserved instances:            %s" % sum(reserved_instances.values()))
+print("Running spot instances:        %s" % sum(six.itervalues(spot_instances)))
+print("Running on-demand instances:   %s" % sum(six.itervalues(running_instances)))
+print("Reserved instances:            %s" % sum(six.itervalues(reserved_instances)))
 print("")

--- a/check-reserved-instances
+++ b/check-reserved-instances
@@ -23,9 +23,9 @@ parser.add_argument("--region", type=str, default="cn-north-1",
 parser.add_argument("-w", "--warn-time", type=int, default=30,
                     help="Expire period for reserved instances in days. "
                          "Default is '30 days'")
-parser.add_argument("-e", "--expire-time", type=int, default=3,
+parser.add_argument("-e", "--expire-time", type=int, default=7,
                     help="Expired period for reserved instances in days. "
-                         "Default is '3 days'")
+                         "Default is '7 days'")
 parser.add_argument("-o", "--order-time", type=int, default=7,
                     help="Payment period for reserved instances in days. "
                          "Default is '7 days'")

--- a/check-reserved-rds-instances
+++ b/check-reserved-rds-instances
@@ -157,8 +157,6 @@ if not new_order_ri:
     print("\tNone")
 print("")
 
-#print("Running on-demand RDS instances: %s" % sum(running_instances.values()))
-#print("Reserved RDS instances:          %s" % sum(reserved_instances.values()))
 print("Running on-demand RDS instances: %s" % sum(six.itervalues(running_instances)))
 print("Reserved RDS instances:          %s" % sum(six.itervalues(reserved_instances)))
 print("")

--- a/check-reserved-rds-instances
+++ b/check-reserved-rds-instances
@@ -157,6 +157,8 @@ if not new_order_ri:
     print("\tNone")
 print("")
 
-print("Running on-demand RDS instances: %s" % sum(running_instances.values()))
-print("Reserved RDS instances:          %s" % sum(reserved_instances.values()))
+#print("Running on-demand RDS instances: %s" % sum(running_instances.values()))
+#print("Reserved RDS instances:          %s" % sum(reserved_instances.values()))
+print("Running on-demand RDS instances: %s" % sum(six.itervalues(running_instances)))
+print("Reserved RDS instances:          %s" % sum(six.itervalues(reserved_instances)))
 print("")


### PR DESCRIPTION
现在只有start  、end  、during 和 now 这四个参数来判断是否转变过类型以及新购买类型，但是无法选择出，转换过并正常过期的预留实例
   
 